### PR TITLE
Fix a Bug that options set manager always stuck at the first option …

### DIFF
--- a/AuditHistoryExtractor/Classes/AuditHistoryManager.cs
+++ b/AuditHistoryExtractor/Classes/AuditHistoryManager.cs
@@ -18,6 +18,9 @@ namespace AuditHistoryExtractor.AppCode
 
 
         private OptionSetManager optionSetManager;
+        
+        //a Dictionary to store the optionSet managers for all options fields in the entity
+        private Dictionary<string, OptionSetManager> optionSetsManagersDict = new Dictionary<string, OptionSetManager>();
 
 
 
@@ -44,13 +47,18 @@ namespace AuditHistoryExtractor.AppCode
                 {
                     OptionSetValue optSetValue = (attributeAuditHistoryDetail[fieldKey] as OptionSetValue);
 
-                    if (optionSetManager == null)
+                    
+                    //if the field was called before, the value will be taken from dictionary
+                    if (optionSetsManagersDict.ContainsKey(fieldKey))
+                    {
+                        optionSetManager = optionSetsManagersDict[fieldKey];
+                    }
+                    else// otherwise a new optionSetManager object will be created and added to the dictionary
                     {
                         optionSetManager = new OptionSetManager(_service);
                         optionSetManager.SetupOptionSetValues(attributeAuditHistoryDetail.LogicalName, fieldKey);
+                        optionSetsManagersDict.Add(fieldKey, optionSetManager);
                     }
-
-                    value = optionSetManager.GetDescriptionOptionSetValue(optSetValue.Value);
                 }
                 else { value = attributeAuditHistoryDetail[fieldKey].ToString(); }
             }

--- a/AuditHistoryExtractor/Classes/AuditHistoryManager.cs
+++ b/AuditHistoryExtractor/Classes/AuditHistoryManager.cs
@@ -18,9 +18,6 @@ namespace AuditHistoryExtractor.AppCode
 
 
         private OptionSetManager optionSetManager;
-        
-        //a Dictionary to store the optionSet managers for all options fields in the entity
-        private Dictionary<string, OptionSetManager> optionSetsManagersDict = new Dictionary<string, OptionSetManager>();
 
 
 
@@ -47,18 +44,13 @@ namespace AuditHistoryExtractor.AppCode
                 {
                     OptionSetValue optSetValue = (attributeAuditHistoryDetail[fieldKey] as OptionSetValue);
 
-                    
-                    //if the field was called before, the value will be taken from dictionary
-                    if (optionSetsManagersDict.ContainsKey(fieldKey))
-                    {
-                        optionSetManager = optionSetsManagersDict[fieldKey];
-                    }
-                    else// otherwise a new optionSetManager object will be created and added to the dictionary
+                    if (optionSetManager == null)
                     {
                         optionSetManager = new OptionSetManager(_service);
                         optionSetManager.SetupOptionSetValues(attributeAuditHistoryDetail.LogicalName, fieldKey);
-                        optionSetsManagersDict.Add(fieldKey, optionSetManager);
                     }
+
+                    value = optionSetManager.GetDescriptionOptionSetValue(optSetValue.Value);
                 }
                 else { value = attributeAuditHistoryDetail[fieldKey].ToString(); }
             }


### PR DESCRIPTION
**Fix a Bug that options set manager always stuck at the first option set field that it found.**

The case that if there are multiple options sets fields in the same entity, your code will always get the text of the options from the first options set field, and that's not correct.

